### PR TITLE
Make cinaps compatible with ocaml 4.04, 4.05 and 4.06

### DIFF
--- a/cinaps.opam
+++ b/cinaps.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.04"}
   "dune" {>= "2.0.0"}
   "re"   {>= "1.8.0"}
   "ppx_jane" {with-test}

--- a/src/runtime/cinaps_runtime.ml
+++ b/src/runtime/cinaps_runtime.ml
@@ -1,3 +1,5 @@
+let split_string_on_char ~sep s = String.split_on_char sep s
+
 open StdLabels
 
 let in_place = ref false
@@ -80,18 +82,6 @@ let write_file fn s =
   let oc = open_out_bin fn in
   output_string oc s;
   close_out oc
-
-let split_string_on_char ~sep s =
-  let open String in
-  let r = ref [] in
-  let j = ref (length s) in
-  for i = length s - 1 downto 0 do
-    if unsafe_get s i = sep then begin
-      r := sub s ~pos:(i + 1) ~len:(!j - i - 1) :: !r;
-      j := i
-    end
-  done;
-  sub s ~pos:0 ~len:!j :: !r
 
 let process_file ~file_name ~file_contents f =
   let tmp_fn, oc = Filename.open_temp_file "cinaps" (Filename.extension file_name) in

--- a/src/runtime/cinaps_runtime.ml
+++ b/src/runtime/cinaps_runtime.ml
@@ -81,6 +81,18 @@ let write_file fn s =
   output_string oc s;
   close_out oc
 
+let split_string_on_char ~sep s =
+  let open String in
+  let r = ref [] in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if unsafe_get s i = sep then begin
+      r := sub s ~pos:(i + 1) ~len:(!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  sub s ~pos:0 ~len:!j :: !r
+
 let process_file ~file_name ~file_contents f =
   let tmp_fn, oc = Filename.open_temp_file "cinaps" (Filename.extension file_name) in
   let expected =
@@ -98,7 +110,7 @@ let process_file ~file_name ~file_contents f =
       | (".ml" | ".mli"), Some cmd -> begin
         let cmd =
           String.concat ~sep:""
-            (match String.split_on_char cmd ~sep:'%' with
+            (match split_string_on_char cmd ~sep:'%' with
              | [] -> assert false
              | x :: l ->
                x :: List.map l ~f:(fun s ->


### PR DESCRIPTION
The only thing preventing it from being compatible with those older compilers was the use of `StringLabels.split_on_char` which was introduced in 4.05.
I tried building it locally and it worked well, I'm not sure why it had a 4.07 lower bound in the first place so I might very well be missing something!