### PR TITLE
Always apply the styler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Next
+
+### Changed
+
+- The styler is now unconditionally applied; it used to be applied only to
+  files with extension ".ml" or ".mli" (#5)
+
 ## v0.15.0
 
 ### Fixed

--- a/src/runtime/cinaps_runtime.ml
+++ b/src/runtime/cinaps_runtime.ml
@@ -96,8 +96,8 @@ let process_file ~file_name ~file_contents f =
       Unix.close Unix.stdout;
       Unix.dup2 stdout_copy Unix.stdout;
       Unix.close stdout_copy;
-      match Filename.extension file_name, !styler with
-      | (".ml" | ".mli"), Some cmd -> begin
+      match !styler with
+      | Some cmd -> begin
         let cmd =
           String.concat ~sep:""
             (match split_string_on_char cmd ~sep:'%' with


### PR DESCRIPTION
The styler used to be applied only to files with the extension
".ml" or ".mli", but is now applied to all files.