### PR TITLE
Fix compilation of generated cinaps files

### DIFF
--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -62,7 +62,7 @@ let main () =
   let init_staged fn =
     let oc = open_out fn in
     staged_output := Some oc;
-    Printf.fprintf oc "let () = Cinaps_runtime.init ()\n"
+    Printf.fprintf oc "let () = Cinaps_runtime.init ();;\n"
   in
   let args =
     Arg.align

--- a/test/dune
+++ b/test/dune
@@ -2,8 +2,7 @@
  (action (bash "%{bin:cinaps} -staged test_staged_gen.ml test_staged.ml")))
 
 (executables (names test_staged_gen) (modules test_staged_gen)
- (libraries cinaps.runtime)
- (preprocess (pps ppx_jane -allow-toplevel-expression)))
+ (libraries cinaps.runtime))
 
 (alias (name runtest) (deps test_staged_gen.exe)
  (action (bash ./test_staged_gen.exe)))

--- a/test/empty-cinaps/dune
+++ b/test/empty-cinaps/dune
@@ -1,0 +1,7 @@
+(rule
+ (targets test_empty.ml)
+ (action (bash "%{bin:cinaps} -staged test_empty.ml")))
+
+(test
+ (libraries cinaps.runtime)
+ (name test_empty))


### PR DESCRIPTION
When one doesn't use any files with cinaps, we this generated file:

``` ocaml
let () = Cinaps_runtime.init ()
Cinaps_runtime.exit ();;
```

This does not compile because there's a missing `;;` after the init. This PR
fixes that (and also removes the unnecssary ppx_jane test dep)