### PR TITLE
create anonymous module in generated code

### DIFF
--- a/cinaps.opam
+++ b/cinaps.opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.10"}
   "dune" {>= "2.0.0"}
   "re"   {>= "1.8.0"}
   "ppx_jane" {with-test}

--- a/src/cinaps.ml
+++ b/src/cinaps.ml
@@ -112,7 +112,7 @@ let main () =
         "let () = Cinaps_runtime.process_file\n\
         \  ~file_name:%S\n\
         \  ~file_contents:%s\n\
-        \  (fun () -> let module M = struct\n"
+        \  (fun () -> let module _ = struct\n"
         fn
         (quote_string file_contents);
       process_file ~f:append_code_block ~syntax ~file_contents ~file_name:fn ~copy_input;


### PR DESCRIPTION
Rather than generating "let module M", generate "let module _" and avoid an unused module name. Updated min ocaml version to 4.10 for "module _" support.