### PR TITLE
Remove unused ppx_jane dependency from opam file

### DIFF
--- a/cinaps.opam
+++ b/cinaps.opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml" {>= "4.10"}
   "dune" {>= "2.0.0"}
   "re"   {>= "1.8.0"}
-  "ppx_jane" {with-test}
   "base-unix"
 ]
 synopsis: "Trivial metaprogramming tool"


### PR DESCRIPTION
I noticed this dependency is no longer used.  FYI, the most recent release cannot be built `--with-test` with ppx_jane >= 0.15.  Would it be possible to cut another patch version?

Thanks!